### PR TITLE
add scripts in separated files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "homepage": "http://ionicframework.com/",
   "private": true,
   "scripts": {
-    "clean": "ionic-app-scripts clean",
-    "build": "ionic-app-scripts build",
-    "ionic:build": "ionic-app-scripts build",
-    "ionic:serve": "ionic-app-scripts serve"
+    "start": "scripts/start.sh",
+    "build": "scripts/build.sh",
+    "clean": "scripts/clean.sh"
   },
   "dependencies": {
     "@angular/common": "2.2.1",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./node_modules/@ionic/app-scripts/bin/ionic-app-scripts.js build

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./node_modules/@ionic/app-scripts/bin/ionic-app-scripts.js clean

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./node_modules/@ionic/app-scripts/bin/ionic-app-scripts.js serve


### PR DESCRIPTION
as suggestion, separate npm scripts in separated files

this allow to call bin of dependencies, without install it as globallly

e.g.

```npm start```

will all shell script in `scripts/start.sh`

the contents of this file, exec the bin of @ionic/app-scripts, located in `./node_modules/@ionic/app-scripts/bin/ionic-app-scripts.js`

is important add the complete path in .sh files, because without full path, the script broken in windows machines